### PR TITLE
7.x islandora altmetrics 1880

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: true
+sudo: required
 language: php
 php:
   - 5.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,4 @@ before_script:
 script:
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_altmetrics
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer sites/all/modules/islandora_altmetrics
-  - phpcpd --names *.module,*.inc,*.test,*.php sites/all/modules/islandora_altmetrics  
-  - php scripts/run-tests.sh --php `phpenv which php` --url http://localhost:8081 --verbose "Islandora Altmetrics"
+  - phpcpd --names *.module,*.inc,*.test,*.php sites/all/modules/islandora_altmetrics  "

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ before_script:
 script:
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_altmetrics
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer sites/all/modules/islandora_altmetrics
-  - phpcpd --names *.module,*.inc,*.test,*.php sites/all/modules/islandora_altmetrics  "
+  - phpcpd --names *.module,*.inc,*.test,*.php sites/all/modules/islandora_altmetrics

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,11 @@ before_install:
   - ln -s $HOME/islandora_solr_search sites/all/modules/islandora_solr_search
   - drush cc all
   - drush -u 1 en --yes islandora_scholar islandora_altmetrics
+before_script:
+  # Mysql might time out for long tests, increase the wait timeout.
+  - mysql -e 'SET @@GLOBAL.wait_timeout=1200'
 script:
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_altmetrics
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer sites/all/modules/islandora_altmetrics
-  - phpcpd --names *.module,*.inc,*.test,*.php sites/all/modules/islandora_altmetrics
-  - drush test-run --uri=http://localhost:8081 "Islandora Altmetrics"
+  - phpcpd --names *.module,*.inc,*.test,*.php sites/all/modules/islandora_altmetrics  
+  - php scripts/run-tests.sh --php `phpenv which php` --url http://localhost:8081 --verbose "Islandora Altmetrics""

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ script:
   - $ISLANDORA_DIR/tests/scripts/line_endings.sh sites/all/modules/islandora_altmetrics
   - drush coder-review --reviews=production,security,style,i18n,potx,sniffer sites/all/modules/islandora_altmetrics
   - phpcpd --names *.module,*.inc,*.test,*.php sites/all/modules/islandora_altmetrics  
-  - php scripts/run-tests.sh --php `phpenv which php` --url http://localhost:8081 --verbose "Islandora Altmetrics""
+  - php scripts/run-tests.sh --php `phpenv which php` --url http://localhost:8081 --verbose "Islandora Altmetrics"


### PR DESCRIPTION
 JIRA Ticket: https://jira.duraspace.org/browse/ISLANDORA-1880

What does this Pull Request do?

Remove Travis-CI Drupal Test invocations made via Drush, which are being deprecated, as there are no tests in this repository. Updates the YAML to have a MySQL timeout so that long running tests don't cause the MySQL session to timeout. Lastly, adds sudo for the YAML as old builds were grandfathered.

What's new?

Removed the from Drush test runner script fro .travis.yml file. Added Sudo in .travis.yml file as it required for the scrips to run, repos before 2015 were grandfathered in. However, this isn't the case for forks. Also, added a before_script in travis.yml file to extend mysql wait time to 1200 as the builds were failing in Travic-ci.org.

Interested parties

@Islandora/7-x-1-x-committers